### PR TITLE
fix #36: KML or GPX export don't work : Class "XMLWriter" not found

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -69,7 +69,7 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "mariadb-server, php8.2-mysql"
+    packages = "mariadb-server, php8.2-mysql, php8.2-xml"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
## Problem

missing php-xml needed for export track to kml or gpx
fix issue #36

## Solution

add `php8.2-xml` to `resources.apt  packages` in `manifest.toml`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
